### PR TITLE
correct the version number of react-router in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "react": "^15.0.2",
     "react-dom": "^15.0.2",
     "react-redux": "^4.4.5",
-    "react-router": "^3.0.0",
+    "react-router": "^2.4.0",
     "redux": "^3.5.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "react": "^15.0.2",
     "react-dom": "^15.0.2",
     "react-redux": "^4.4.5",
-    "react-router": "^2.4.0",
+    "react-router": "^3.0.0-alpha.1",
     "redux": "^3.5.2"
   },
   "devDependencies": {


### PR DESCRIPTION
`npm install` will fail if the version number of react-router is `3.0.0`.  This affects every branch from `08-using-withrouter-to-inject-params-into-connected-components` to `27-updating-data-on-the-server`
