### PR TITLE
FIX: No compatible version found: react-router@^3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "react": "^15.0.2",
     "react-dom": "^15.0.2",
     "react-redux": "^4.4.5",
-    "react-router": "^3.0.0",
+    "react-router": "^3.0.0-alpha.3",
     "redux": "^3.5.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Currently the latest version of `react-router` is `3.0.0-alpha.3`.
